### PR TITLE
feat(pumpfun): align src/ with 2026-04-28 program upgrade + cashback path

### DIFF
--- a/src/platforms/pumpfun/address_provider.py
+++ b/src/platforms/pumpfun/address_provider.py
@@ -6,7 +6,7 @@ by implementing the AddressProvider interface.
 """
 
 from dataclasses import dataclass
-from typing import Final
+from typing import ClassVar, Final
 
 from solders.pubkey import Pubkey
 from spl.token.instructions import get_associated_token_address
@@ -43,6 +43,29 @@ class PumpFunAddresses:
     FEE_PROGRAM: Final[Pubkey] = Pubkey.from_string(
         "pfeeUxB6jkeY1Hxd7CsFCAjcbHA9rWtchMGdZ6VojVZ"
     )
+    # 8 breaking-upgrade fee recipients (pump.fun program upgrade 2026-04-28).
+    # One must be appended (mutable) AFTER bonding-curve-v2 on every buy/sell.
+    # Doc: github.com/pump-fun/pump-public-docs/blob/main/docs/BREAKING_FEE_RECIPIENT.md
+    BREAKING_FEE_RECIPIENTS: ClassVar[list[Pubkey]] = [
+        Pubkey.from_string("5YxQFdt3Tr9zJLvkFccqXVUwhdTWJQc1fFg2YPbxvxeD"),
+        Pubkey.from_string("9M4giFFMxmFGXtc3feFzRai56WbBqehoSeRE5GK7gf7"),
+        Pubkey.from_string("GXPFM2caqTtQYC2cJ5yJRi9VDkpsYZXzYdwYpGnLmtDL"),
+        Pubkey.from_string("3BpXnfJaUTiwXnJNe7Ej1rcbzqTTQUvLShZaWazebsVR"),
+        Pubkey.from_string("5cjcW9wExnJJiqgLjq7DEG75Pm6JBgE1hNv4B2vHXUW6"),
+        Pubkey.from_string("EHAAiTxcdDwQ3U4bU6YcMsQGaekdzLS3B5SmYo46kJtL"),
+        Pubkey.from_string("5eHhjP8JaYkz83CWwvGU2uMUXefd3AazWGx4gpcuEEYD"),
+        Pubkey.from_string("A7hAgCzFw14fejgCp387JUJRMNyz4j89JKnhtKU8piqW"),
+    ]
+
+    @staticmethod
+    def pick_breaking_fee_recipient() -> Pubkey:
+        """Pick one of the 8 breaking-upgrade fee recipients at random.
+
+        Spreads load across recipients per pump.fun's recommendation.
+        """
+        import random
+
+        return random.choice(PumpFunAddresses.BREAKING_FEE_RECIPIENTS)
 
     @staticmethod
     def find_global_volume_accumulator() -> Pubkey:
@@ -354,6 +377,7 @@ class PumpFunAddressProvider(AddressProvider):
             "fee_config": self.derive_fee_config(),
             "fee_program": PumpFunAddresses.FEE_PROGRAM,
             "bonding_curve_v2": self.derive_bonding_curve_v2(token_info.mint),
+            "breaking_fee_recipient": PumpFunAddresses.pick_breaking_fee_recipient(),
         }
 
     def get_sell_instruction_accounts(
@@ -405,4 +429,5 @@ class PumpFunAddressProvider(AddressProvider):
             "fee_program": PumpFunAddresses.FEE_PROGRAM,
             "bonding_curve_v2": self.derive_bonding_curve_v2(token_info.mint),
             "user_volume_accumulator": self.derive_user_volume_accumulator(user),
+            "breaking_fee_recipient": PumpFunAddresses.pick_breaking_fee_recipient(),
         }

--- a/src/platforms/pumpfun/event_parser.py
+++ b/src/platforms/pumpfun/event_parser.py
@@ -274,6 +274,7 @@ class PumpFunEventParser(EventParser):
                         creator=creator,
                         creator_vault=creator_vault,
                         token_program_id=token_program_id,
+                        is_mayhem_mode=fields.get("is_mayhem_mode", False),
                         is_cashback_coin=fields.get("is_cashback_enabled", False),
                         creation_timestamp=monotonic(),
                     )
@@ -384,6 +385,7 @@ class PumpFunEventParser(EventParser):
                 creator=creator,
                 creator_vault=creator_vault,
                 token_program_id=token_program_id,
+                is_mayhem_mode=bool(args.get("is_mayhem_mode", False)),
                 is_cashback_coin=is_cashback,
                 creation_timestamp=monotonic(),
             )

--- a/src/platforms/pumpfun/instruction_builder.py
+++ b/src/platforms/pumpfun/instruction_builder.py
@@ -149,6 +149,12 @@ class PumpFunInstructionBuilder(InstructionBuilder):
                 is_signer=False,
                 is_writable=False,
             ),
+            # 18th account: breaking-upgrade fee recipient (mutable) — required from 2026-04-28
+            AccountMeta(
+                pubkey=accounts_info["breaking_fee_recipient"],
+                is_signer=False,
+                is_writable=True,
+            ),
         ]
 
         # Build instruction data: discriminator + token_amount + max_sol_cost + track_volume
@@ -271,6 +277,14 @@ class PumpFunInstructionBuilder(InstructionBuilder):
                 is_writable=False,
             )
         )
+        # 16/17th account: breaking-upgrade fee recipient (mutable) — required from 2026-04-28
+        sell_accounts.append(
+            AccountMeta(
+                pubkey=accounts_info["breaking_fee_recipient"],
+                is_signer=False,
+                is_writable=True,
+            )
+        )
 
         # Build instruction data: discriminator + token_amount + min_sol_output + track_volume
         # Encode OptionBool for track_volume: [1, 1] = Some(true)
@@ -319,6 +333,7 @@ class PumpFunInstructionBuilder(InstructionBuilder):
             accounts_info["fee_config"],
             accounts_info["fee_program"],
             accounts_info["bonding_curve_v2"],
+            accounts_info["breaking_fee_recipient"],
         ]
 
     def get_required_accounts_for_sell(
@@ -347,6 +362,7 @@ class PumpFunInstructionBuilder(InstructionBuilder):
             accounts_info["fee_config"],
             accounts_info["fee_program"],
             accounts_info["bonding_curve_v2"],
+            accounts_info["breaking_fee_recipient"],
         ]
 
     def calculate_token_amount_raw(self, token_amount_decimal: float) -> int:

--- a/src/trading/platform_aware.py
+++ b/src/trading/platform_aware.py
@@ -77,8 +77,13 @@ class PlatformAwareBuyer(Trader):
                         f"(mint: {token_info.mint}) - cannot execute buy with zero/invalid price"
                     )
 
-                # Set is_mayhem_mode from bonding curve state
+                # Set mayhem-mode and cashback flags from bonding-curve state
+                # so the instruction builder picks the correct fee_recipient and
+                # account-list shape (cashback sells use 17 accounts, non-cashback 16).
                 token_info.is_mayhem_mode = pool_state.get("is_mayhem_mode", False)
+                token_info.is_cashback_coin = pool_state.get(
+                    "is_cashback_coin", token_info.is_cashback_coin
+                )
                 token_amount = self.amount / token_price_sol
 
             # Calculate minimum token amount with slippage
@@ -304,6 +309,28 @@ class PlatformAwareSeller(Trader):
             )
             address_provider = implementations.address_provider
             instruction_builder = implementations.instruction_builder
+            curve_manager = implementations.curve_manager
+
+            # Refresh mayhem-mode and cashback flags from curve state.
+            # The sell account list is 16 (non-cashback) vs 17 (cashback), and
+            # fee_recipient differs in mayhem mode — both can change between
+            # buy and sell, so re-read from chain instead of trusting create-time
+            # flags carried in token_info.
+            try:
+                pool_address = self._get_pool_address(token_info, address_provider)
+                pool_state = await curve_manager.get_pool_state(pool_address)
+                token_info.is_mayhem_mode = pool_state.get(
+                    "is_mayhem_mode", token_info.is_mayhem_mode
+                )
+                token_info.is_cashback_coin = pool_state.get(
+                    "is_cashback_coin", token_info.is_cashback_coin
+                )
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    f"Could not refresh curve flags before sell ({e}); "
+                    f"using token_info values is_mayhem_mode={token_info.is_mayhem_mode}, "
+                    f"is_cashback_coin={token_info.is_cashback_coin}"
+                )
 
             # Use pre-known amount and price (no RPC delay)
             token_balance_decimal = token_amount


### PR DESCRIPTION
## Summary
Mirrors the four learning-examples commits (`9b48418`, `c25e2ed`, `57ffe8b`, `ad6d2cc`) into the production code paths under `src/`, so the bot keeps working through the **2026-04-28 16:00 UTC pump.fun program upgrade**. Affects only `pump_fun`; `lets_bonk` untouched. PumpSwap is not implemented under `src/` so the pool-v2 + breaking-fee-recipient pumpswap accounts are out of scope here (they live in `learning-examples/pumpswap/`).

## Changes

### `src/platforms/pumpfun/address_provider.py`
- Adds `BREAKING_FEE_RECIPIENTS: ClassVar[list[Pubkey]]` with the 8 addresses pump.fun published for the upgrade.
- Adds `pick_breaking_fee_recipient()` — `random.choice` across the 8 to spread program-tx throughput per pump.fun's recommendation.
- `get_buy_instruction_accounts` and `get_sell_instruction_accounts` now expose `"breaking_fee_recipient"` alongside the existing keys.

### `src/platforms/pumpfun/instruction_builder.py`
- BC **buy** ix: appends `breaking_fee_recipient` (mutable) AFTER `bonding_curve_v2` → **18 accounts** total (was 17).
- BC **sell** ix: appends `breaking_fee_recipient` (mutable) AFTER `bonding_curve_v2` for both cashback and non-cashback paths → **16** accounts non-cashback / **17** cashback (was 15 / 16).
- `get_required_accounts_for_{buy,sell}` updated to include the new account so priority-fee scraping covers it.

### `src/platforms/pumpfun/event_parser.py`
- `is_mayhem_mode` is now extracted into `TokenInfo` on both paths (logs CreateEvent + instruction `create` / `create_v2`); previously only `is_cashback_coin` was carried forward, leaving `extreme_fast_mode` buys to use the wrong `fee_recipient` on Mayhem-Mode tokens.

### `src/trading/platform_aware.py`
- Buy non-extreme path now also refreshes `is_cashback_coin` from `pool_state` (was only `is_mayhem_mode`).
- Sell path now refreshes both flags from curve state before building the sell ix, so a coin that flips cashback after buy still gets the correct 16-vs-17-account layout. Wrapped in `try/except` so a transient RPC failure logs a warning and falls back to `token_info` defaults rather than failing the sell outright.

## Test plan
Live-validated all four `bots/*.yaml` configs end-to-end on mainnet against fresh tokens (extreme_fast_mode, 0.0001 SOL buy, time_based 15s exit):

- [x] `bot-sniper-2-logs.yaml` — HITLOR buy [`4GVJJwYt…`](https://explorer.solana.com/tx/4GVJJwYtGixSPAQimgUhNYjEUBG6TB9XeQjKxs9EWpw2QfWuq7LHmUivPrsjhESgaPsPJQ9N6CCxECqxm9csqrH9) → sell [`2ijgoPgx…`](https://explorer.solana.com/tx/2ijgoPgxPmcSX4mFqz1PVkZ3yAvu36vj3Jy1yWZofxrK7jR92j2DWP3tRNy9PmUd1kiTaoYzVsrpGr6286KCnTp7) — verified 18/16 accounts on-chain
- [x] `bot-sniper-3-blocks.yaml` — TKNZ buy [`4siRLG7t…`](https://explorer.solana.com/tx/4siRLG7tYk9iHyXAvnp3DH54vQXVEDHmCqZRmFgYhnRB9mVGjhh43ywohKjg8CpWctt5TyCtDkLRTRWT6VDwVyZi) → sell [`46jShWJ3…`](https://explorer.solana.com/tx/46jShWJ3sfuCP4YgTcpXWZdyqVmw4ULQSTC3Kwvbc9hE2y4yDosBww8Un8anXZpR1Xf96rN9QusV1G92oNcbp1o3)
- [x] `bot-sniper-1-geyser.yaml` — OURO buy [`4UEZy7LP…`](https://explorer.solana.com/tx/4UEZy7LPm7Rxgw22d1bduQHTWHHHYJSpuaoq2iCyPFpnBPGt4C3QUCu9x77vwWugXnyGv4pQQeTbEZEjvyxxiDH2) → sell [`21hSHVPK…`](https://explorer.solana.com/tx/21hSHVPKtqse25XybxhdGrpqK1fSxKKeNZGDCD5j568mzRPfyYR1TQs6mAc2moHKT7kaAAfdMC8DPt8VXmu2rviF) — curve-refresh fallback also exercised on the sell side
- [x] `bot-sniper-4-pp.yaml` — Frogman buy [`4P91y4iP…`](https://explorer.solana.com/tx/4P91y4iPK6y1gPjz65VL6XAcVkT4DbqjHE5vHfX8PLnzqViCy1qZQ44eWiNDUPzoWCejibB7UJPKYAEj4K3Z3c3S) ✓ ; sell hit `Custom 6003` (`TooLittleSolReceived` at `lib.rs:696`) — **program-side slippage protection**, proof the ix passed deserialization and reached the swap math
- [x] No PumpSwap path exists under `src/` (verified by audit) — out of scope
- [x] `bots/*.yaml` configs reverted to their original state at the end

## Notes
- The vendored IDL in `idl/pump_fun_idl.json` is missing the `bonding-curve-v2` PDA account that pump.fun's program actually requires — `address_provider.derive_bonding_curve_v2()` already handles this.
- Companion change for the upcoming **PumpSwap upgrade** (April 28 +2 accounts) lives in `learning-examples/pumpswap/*` behind `INCLUDE_BREAKING_FEE_ACCOUNTS = False` — flip that to `True` after **2026-04-28 16:00 UTC**. PumpSwap is not exercised by `src/` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for mayhem mode token detection during token creation
  * Implemented random breaking fee recipient selection for buy and sell transactions
  * Enhanced buyer and seller to read mayhem mode and cashback coin flags from pool state

* **Bug Fixes**
  * Seller now re-fetches current token flags from pool state before execution to prevent stale data usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->