### PR TITLE
fix(learning-examples): replace getProgramAccounts scan in get_graduating_tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,8 +182,25 @@ offline and only visible after a couple of minutes against mainnet.
 - **`getProgramAccounts` over the whole pump program is rejected** by current
   providers: *"Too many accounts requested (10000001 pubkeys) … use
   getProgramAccountsV2 with pagination"*. It still works against pump-amm, which
-  is small enough. `bonding-curve-progress/get_graduating_tokens.py` is knowingly
-  broken on this and needs the V2 pagination rewrite.
+  is small enough. Don't take that error message as a fix: `getProgramAccountsV2`
+  is a provider extension (Helius, Solana Tracker), **not core Agave**, and its
+  `limit` is a *scan* budget rather than a result count — a page can legally
+  return zero accounts and a non-null `paginationKey`, so one filtered answer over
+  the pump program costs ~1000 sequential pages. Reach for a filtered
+  subscription instead; see the two `get_graduating_tokens*.py` examples.
+- **Filtered `programSubscribe` on the pump program is the portable way to find
+  curves by state.** `dataSize` + `memcmp` are applied server-side, and it is
+  accepted even by the public `api.mainnet-beta.solana.com`. Because `memcmp`
+  matches exact bytes, the only inequality it can express on a little-endian u64
+  is "the top N bytes are zero" (`value < 2**(8*(8-N))`), so thresholds land on
+  coarse power-of-2 gates and the exact comparison has to happen client-side.
+  Geyser's account filters have the same shape and add the slot and signature.
+- **Resolve a curve's mint under Token-2022, not SPL Token.** The curve account
+  has no mint field and `["bonding-curve", mint]` is not reversible, so the mint
+  comes from the associated bonding curve ATA — which is Token-2022 for every
+  `create_v2` coin. `get_token_accounts_by_owner` with the SPL Token program
+  returns an empty list for all of them, silently. Verified four for four on live
+  curves, each confirmed by re-deriving the curve PDA from the recovered mint.
 - **`SetLoadedAccountsDataSizeLimit` must stay generous: 16 MB, not 512 KB.**
   Verified by simulation on a Token-2022 mint with extensions — 512 KB and 4 MB
   both fail `MaxLoadedAccountsDataSizeExceeded` with `unitsConsumed=0` (never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,11 +190,11 @@ offline and only visible after a couple of minutes against mainnet.
   subscription instead; see the two `get_graduating_tokens*.py` examples.
 - **Filtered `programSubscribe` on the pump program is the portable way to find
   curves by state.** `dataSize` + `memcmp` are applied server-side, and it is
-  accepted even by the public `api.mainnet-beta.solana.com`. Because `memcmp`
-  matches exact bytes, the only inequality it can express on a little-endian u64
-  is "the top N bytes are zero" (`value < 2**(8*(8-N))`), so thresholds land on
-  coarse power-of-2 gates and the exact comparison has to happen client-side.
-  Geyser's account filters have the same shape and add the slot and signature.
+  accepted even by the public `api.mainnet-beta.solana.com`. `memcmp` only matches
+  exact bytes, so it cannot express "reserves below X" — only a handful of fixed
+  cutoffs. Treat it as a bandwidth saver and do the real comparison client-side;
+  don't assume a threshold is being enforced upstream. Geyser's account filters
+  have the same shape and add the slot and signature.
 - **Resolve a curve's mint under Token-2022, not SPL Token.** The curve account
   has no mint field and `["bonding-curve", mint]` is not reversible, so the mint
   comes from the associated bonding curve ATA — which is Token-2022 for every

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Standalone scripts, runnable with `uv run <path>`. No bot config needed — they
 |---|---|
 | `listen-new-tokens/` | One listener per method (`logs`, `blocks`, `geyser`, `pumpportal`) plus `compare_listeners.py` to race them |
 | `listen-migrations/` | Detect a token graduating from the bonding curve to PumpSwap, via the migration wrapper program or new pool accounts |
-| `bonding-curve-progress/` | Curve state, progress polling, and tokens close to graduating |
+| `bonding-curve-progress/` | Curve state, progress polling, and a live watch for coins close to graduating — over WebSocket (`get_graduating_tokens.py`) or Geyser (`get_graduating_tokens_geyser.py`), both taking `--min-progress` |
 | `pumpswap/` | Manual buy/sell against the PumpSwap AMM, and pool discovery |
 | `letsbonk-buy-sell/` | Manual exact-in / exact-out buys and sells on letsbonk.fun |
 | `copy-trading/` | Watch another wallet's transactions |
@@ -148,6 +148,8 @@ Related docs: [Listening to pump.fun migrations](https://docs.chainstack.com/doc
 ## Throughput and rate limits
 
 Every node provider has its own limits — method availability, requests per second, plan-specific caps. Consult your provider's docs before running the bot, and don't expect public RPC nodes to hold up.
+
+One case worth knowing about: `getProgramAccounts` over the whole pump.fun program is no longer served by anyone. That program owns more than 10 million accounts, so providers reject the request or time out no matter which filters you pass. Use a filtered subscription instead — `bonding-curve-progress/get_graduating_tokens.py` shows the pattern.
 
 For Chainstack, the numbers you need are in the [throughput guidelines](https://docs.chainstack.com/docs/limits), kept up to date.
 

--- a/learning-examples/bonding-curve-progress/get_graduating_tokens.py
+++ b/learning-examples/bonding-curve-progress/get_graduating_tokens.py
@@ -27,21 +27,27 @@ Progress is measured against `Global.initial_real_token_reserves` (~793.1M token
 read from chain, not a hardcoded constant, because a mayhem coin can launch with
 different virtual params and would otherwise show the wrong percentage.
 
-`memcmp` compares exact bytes, so the only inequality it can express on a
-little-endian u64 is "the top N bytes are zero", i.e. `value < 2**(8*(8-N))`.
-`real_token_reserves` spans offsets 24..31, so the top N bytes sit at offset 32-N.
-That gives these server-side gates, against a 793.1M baseline:
+The pre-filter the server applies can only match exact bytes, so it cannot do
+"anything above 90%". It can only do a few fixed cutoffs. `--min-progress` uses the
+closest cutoff that is still wide enough, then makes the exact comparison here:
 
-    offset  zero bytes  admits reserves below      ≈ progress above
-    31      1           2**56  (72,057,594M tok)   0%      (no real filtering)
-    30      2           2**48  (281.47M tok)       64.51%
-    29      3           2**40  (1.0995M tok)       99.86%
-    28      4           2**32  (4,294.97 tok)      99.9995%
+    filter               cutoff                 ≈ graduated past
+    2 zero bytes @ 30    281.5M tokens left     64.5%
+    3 zero bytes @ 29    1.1M tokens left       99.86%
+    4 zero bytes @ 28    4,295 tokens left      99.9995%
 
-The steps are coarse — 64.51% jumps straight to 99.86% — so `--min-progress`
-picks the tightest gate that still admits every qualifying curve and the exact
-threshold is applied client-side. To hand-tune, change the gate: watching for the
-last moments before migration wants offset 29, a wider funnel wants offset 30.
+    --min-progress       pre-filtered by the server?
+    below 64.5%          no, every curve arrives and is filtered here
+    64.5% to 99.86%      yes, at the 64.5% cutoff
+    99.86% and up        yes, at the 99.86% cutoff
+
+So the pre-filter saves traffic, it does not decide the answer — whatever percentage
+you ask for is honoured either way. Low thresholds just cost more bandwidth. If you
+want to hand-tune, pick a different cutoff from the table: the last moments before
+migration want the 3-byte one, a wider funnel the 2-byte one.
+
+Checked against mainnet by running the filtered and unfiltered subscriptions side by
+side for a minute: same curves, nothing dropped, nothing extra.
 
 `dataSize: 151` restricts this to the current curve layout. The original 49-byte
 layout (no `creator` field) still has accounts with `complete = false`, but none of
@@ -120,19 +126,22 @@ RECONNECT_DELAY: Final[int] = 5
 
 
 def zero_prefix_gate(bound_raw: int) -> tuple[int, bytes] | None:
-    """Pick the tightest `memcmp` gate that still admits `real_token_reserves`.
+    """Pick the tightest server-side cutoff that still lets every match through.
 
-    See the module docstring for the derivation.
+    See the module docstring for the cutoffs on offer. Returns None when none of
+    them is wide enough to be safe, in which case there is no pre-filtering and
+    every curve is checked here instead.
 
     Args:
-        bound_raw: Highest `real_token_reserves` value, in raw units, that should
-            still qualify
+        bound_raw: Highest reserves value, in raw units, that should still qualify
 
     Returns:
-        An (offset, zero bytes) pair for a memcmp filter, or None if not even the
-        widest gate would constrain anything
+        An (offset, zero bytes) pair for a memcmp filter, or None for no filter
     """
-    for zero_bytes in (4, 3, 2, 1):
+    # Only 2, 3 and 4 zero bytes are offered. One zero byte would be a cutoff so
+    # high that no coin could ever fail it, which filters nothing while looking
+    # like it does.
+    for zero_bytes in (4, 3, 2):
         if 2 ** (8 * (8 - zero_bytes)) > bound_raw:
             return 32 - zero_bytes, bytes(zero_bytes)
     return None
@@ -274,14 +283,14 @@ def print_banner(baseline: float, min_progress: float) -> None:
 
     gate = zero_prefix_gate(progress_to_bound(baseline, min_progress))
     if gate:
-        offset, zeros = gate
-        admits = 2 ** (8 * (8 - len(zeros))) / 10**TOKEN_DECIMALS
+        cutoff_tokens = 2 ** (8 * (8 - len(gate[1]))) / 10**TOKEN_DECIMALS
+        cutoff_pct = max(100 - cutoff_tokens * 100 / baseline, 0.0)
         print(
-            f"Server-side gate: memcmp {len(zeros)} zero byte(s) at offset {offset}, "
-            f"admitting reserves below {admits:,.0f} tokens"
+            f"Pre-filter: the server sends only curves past ~{cutoff_pct:.2f}% "
+            f"({cutoff_tokens:,.0f} tokens left); the rest is checked here"
         )
     else:
-        print("Server-side gate: none (threshold too low to constrain)")
+        print("Pre-filter: none, so every curve arrives and is checked here")
     print("Waiting for trades on qualifying curves...\n")
 
 

--- a/learning-examples/bonding-curve-progress/get_graduating_tokens_geyser.py
+++ b/learning-examples/bonding-curve-progress/get_graduating_tokens_geyser.py
@@ -24,22 +24,27 @@ Progress is measured against `Global.initial_real_token_reserves` (~793.1M token
 read from chain, not a hardcoded constant, because a mayhem coin can launch with
 different virtual params and would otherwise show the wrong percentage.
 
-Geyser's account filters are the same shape as the RPC's — `datasize` and exact-byte
-`memcmp` — so the only inequality expressible on a little-endian u64 is "the top N
-bytes are zero", i.e. `value < 2**(8*(8-N))`. `real_token_reserves` spans offsets
-24..31, so the top N bytes sit at offset 32-N, giving these gates against a 793.1M
-baseline:
+The pre-filter the server applies can only match exact bytes, so it cannot do
+"anything above 90%". It can only do a few fixed cutoffs. `--min-progress` uses the
+closest cutoff that is still wide enough, then makes the exact comparison here:
 
-    offset  zero bytes  admits reserves below      ≈ progress above
-    31      1           2**56  (72,057,594M tok)   0%      (no real filtering)
-    30      2           2**48  (281.47M tok)       64.51%
-    29      3           2**40  (1.0995M tok)       99.86%
-    28      4           2**32  (4,294.97 tok)      99.9995%
+    filter               cutoff                 ≈ graduated past
+    2 zero bytes @ 30    281.5M tokens left     64.5%
+    3 zero bytes @ 29    1.1M tokens left       99.86%
+    4 zero bytes @ 28    4,295 tokens left      99.9995%
 
-The steps are coarse — 64.51% jumps straight to 99.86% — so `--min-progress` picks the
-tightest gate that still admits every qualifying curve and the exact threshold is
-applied client-side. To hand-tune, change the gate: the last moments before migration
-want offset 29, a wider funnel wants offset 30.
+    --min-progress       pre-filtered by the server?
+    below 64.5%          no, every curve arrives and is filtered here
+    64.5% to 99.86%      yes, at the 64.5% cutoff
+    99.86% and up        yes, at the 99.86% cutoff
+
+So the pre-filter saves traffic, it does not decide the answer — whatever percentage
+you ask for is honoured either way. Low thresholds just cost more bandwidth. If you
+want to hand-tune, pick a different cutoff from the table: the last moments before
+migration want the 3-byte one, a wider funnel the 2-byte one.
+
+Checked against mainnet by running the filtered and unfiltered subscriptions side by
+side for a minute: same curves, nothing dropped, nothing extra.
 
 `datasize = 151` restricts this to the current curve layout. The original 49-byte
 layout still has accounts with `complete = false`, but none of them are written to any
@@ -128,19 +133,22 @@ RECONNECT_DELAY: Final[int] = 5
 
 
 def zero_prefix_gate(bound_raw: int) -> tuple[int, bytes] | None:
-    """Pick the tightest `memcmp` gate that still admits `real_token_reserves`.
+    """Pick the tightest server-side cutoff that still lets every match through.
 
-    See the module docstring for the derivation.
+    See the module docstring for the cutoffs on offer. Returns None when none of
+    them is wide enough to be safe, in which case there is no pre-filtering and
+    every curve is checked here instead.
 
     Args:
-        bound_raw: Highest `real_token_reserves` value, in raw units, that should
-            still qualify
+        bound_raw: Highest reserves value, in raw units, that should still qualify
 
     Returns:
-        An (offset, zero bytes) pair for a memcmp filter, or None if not even the
-        widest gate would constrain anything
+        An (offset, zero bytes) pair for a memcmp filter, or None for no filter
     """
-    for zero_bytes in (4, 3, 2, 1):
+    # Only 2, 3 and 4 zero bytes are offered. One zero byte would be a cutoff so
+    # high that no coin could ever fail it, which filters nothing while looking
+    # like it does.
+    for zero_bytes in (4, 3, 2):
         if 2 ** (8 * (8 - zero_bytes)) > bound_raw:
             return 32 - zero_bytes, bytes(zero_bytes)
     return None
@@ -326,14 +334,14 @@ def print_banner(baseline: float, min_progress: float) -> None:
 
     gate = zero_prefix_gate(progress_to_bound(baseline, min_progress))
     if gate:
-        offset, zeros = gate
-        admits = 2 ** (8 * (8 - len(zeros))) / 10**TOKEN_DECIMALS
+        cutoff_tokens = 2 ** (8 * (8 - len(gate[1]))) / 10**TOKEN_DECIMALS
+        cutoff_pct = max(100 - cutoff_tokens * 100 / baseline, 0.0)
         print(
-            f"Server-side gate: memcmp {len(zeros)} zero byte(s) at offset {offset}, "
-            f"admitting reserves below {admits:,.0f} tokens"
+            f"Pre-filter: the server sends only curves past ~{cutoff_pct:.2f}% "
+            f"({cutoff_tokens:,.0f} tokens left); the rest is checked here"
         )
     else:
-        print("Server-side gate: none (threshold too low to constrain)")
+        print("Pre-filter: none, so every curve arrives and is checked here")
     print("Waiting for trades on qualifying curves...\n")
 
 

--- a/learning-examples/bonding-curve-progress/get_graduating_tokens_geyser.py
+++ b/learning-examples/bonding-curve-progress/get_graduating_tokens_geyser.py
@@ -1,25 +1,22 @@
-"""Watch for pump.fun coins approaching graduation, over plain WebSocket RPC.
+"""Watch for pump.fun coins approaching graduation, over Geyser gRPC.
 
 Usage:
-    uv run learning-examples/bonding-curve-progress/get_graduating_tokens.py
-    uv run learning-examples/bonding-curve-progress/get_graduating_tokens.py --min-progress 95
+    uv run learning-examples/bonding-curve-progress/get_graduating_tokens_geyser.py
+    uv run learning-examples/bonding-curve-progress/get_graduating_tokens_geyser.py --min-progress 95
 
-Why a subscription and not `getProgramAccounts`: the pump.fun program now owns
-over 10 million accounts, and every provider refuses to scan it. Helius, Alchemy
-and dRPC reject with `Too many accounts requested (10000001 pubkeys)`; QuickNode
-and Chainstack time out. No filter set fixes that — the rejection is on program
-size, before filters apply. `getProgramAccountsV2` is a provider extension (Helius,
-Solana Tracker), not core Agave, and its `limit` is a *scan* budget rather than a
-result count, so answering this question with it means ~1000 sequential pages.
+Needs GEYSER_ENDPOINT, GEYSER_API_TOKEN and GEYSER_AUTH_TYPE in .env, plus
+SOLANA_NODE_RPC_ENDPOINT for the two things the stream cannot answer: the Global
+baseline and each coin's mint. Geyser is a paid add-on, so `get_graduating_tokens.py`
+is the portable version of this report — it runs on any endpoint, including the public
+one. This variant exists because Geyser is common among traders and gives you the slot
+and transaction signature behind every update, which the WebSocket feed does not.
 
-`programSubscribe` sidesteps the scan entirely. A curve can only approach
-graduation by being traded, and every write to it pushes the full 151-byte account,
-so each notification carries everything needed to compute progress — there is no
-state to accumulate and no cold start beyond the next trade. Verified accepted on
-both a paid endpoint and the public `api.mainnet-beta.solana.com`.
-
-See `get_graduating_tokens_geyser.py` for the same report over Geyser gRPC, which
-also gives you the transaction signature behind each update.
+Why a subscription and not `getProgramAccounts`: the pump.fun program now owns over
+10 million accounts, and every provider refuses to scan it — the rejection is on
+program size, before filters apply. A curve can only approach graduation by being
+traded, and every write pushes the full 151-byte account, so each update carries
+everything needed to compute progress: no accumulated state, no cold start beyond the
+next trade.
 
 Selecting a graduation threshold
 --------------------------------
@@ -27,10 +24,11 @@ Progress is measured against `Global.initial_real_token_reserves` (~793.1M token
 read from chain, not a hardcoded constant, because a mayhem coin can launch with
 different virtual params and would otherwise show the wrong percentage.
 
-`memcmp` compares exact bytes, so the only inequality it can express on a
-little-endian u64 is "the top N bytes are zero", i.e. `value < 2**(8*(8-N))`.
-`real_token_reserves` spans offsets 24..31, so the top N bytes sit at offset 32-N.
-That gives these server-side gates, against a 793.1M baseline:
+Geyser's account filters are the same shape as the RPC's — `datasize` and exact-byte
+`memcmp` — so the only inequality expressible on a little-endian u64 is "the top N
+bytes are zero", i.e. `value < 2**(8*(8-N))`. `real_token_reserves` spans offsets
+24..31, so the top N bytes sit at offset 32-N, giving these gates against a 793.1M
+baseline:
 
     offset  zero bytes  admits reserves below      ≈ progress above
     31      1           2**56  (72,057,594M tok)   0%      (no real filtering)
@@ -38,37 +36,46 @@ That gives these server-side gates, against a 793.1M baseline:
     29      3           2**40  (1.0995M tok)       99.86%
     28      4           2**32  (4,294.97 tok)      99.9995%
 
-The steps are coarse — 64.51% jumps straight to 99.86% — so `--min-progress`
-picks the tightest gate that still admits every qualifying curve and the exact
-threshold is applied client-side. To hand-tune, change the gate: watching for the
-last moments before migration wants offset 29, a wider funnel wants offset 30.
+The steps are coarse — 64.51% jumps straight to 99.86% — so `--min-progress` picks the
+tightest gate that still admits every qualifying curve and the exact threshold is
+applied client-side. To hand-tune, change the gate: the last moments before migration
+want offset 29, a wider funnel wants offset 30.
 
-`dataSize: 151` restricts this to the current curve layout. The original 49-byte
-layout (no `creator` field) still has accounts with `complete = false`, but none of
-them are written to any more — verified over a 45s window in which all 205 updates
-across 24 curves were 151-byte accounts.
+`datasize = 151` restricts this to the current curve layout. The original 49-byte
+layout still has accounts with `complete = false`, but none of them are written to any
+more — verified over a 45s window in which all 205 updates across 24 curves were
+151-byte accounts.
 """
 
 import argparse
 import asyncio
-import base64
-import json
 import os
 import struct
 import sys
+from pathlib import Path
 from typing import Any, Final
 
-import websockets
+import grpc
 from dotenv import load_dotenv
 from solana.rpc.async_api import AsyncClient
 from solana.rpc.types import TokenAccountOpts
 from solders.pubkey import Pubkey
+from solders.signature import Signature
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from src.geyser.generated import (
+    geyser_pb2,
+    geyser_pb2_grpc,
+)
 
 load_dotenv()
 
 # Constants
 RPC_ENDPOINT: Final[str] = os.environ.get("SOLANA_NODE_RPC_ENDPOINT", "")
-WSS_ENDPOINT: Final[str] = os.environ.get("SOLANA_NODE_WSS_ENDPOINT", "")
+GEYSER_ENDPOINT: Final[str] = os.environ.get("GEYSER_ENDPOINT", "")
+GEYSER_API_TOKEN: Final[str] = os.environ.get("GEYSER_API_TOKEN", "")
+GEYSER_AUTH_TYPE: Final[str] = os.environ.get("GEYSER_AUTH_TYPE", "x-token").lower()
+
 PUMP_PROGRAM_ID: Final[Pubkey] = Pubkey.from_string(
     "6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P"
 )
@@ -76,8 +83,8 @@ PUMP_GLOBAL: Final[Pubkey] = Pubkey.from_string(
     "4wTV1YmiEkRvAtNtsSGPtUrqRYQMe5SKy2uB4Jjaxnjf"
 )
 
-# Coins created by `create_v2` are Token-2022, so that is tried first. Querying
-# under the wrong token program returns nothing at all.
+# Coins created by `create_v2` are Token-2022, so that is tried first. Querying under
+# the wrong token program returns nothing at all.
 TOKEN_2022_PROGRAM_ID: Final[Pubkey] = Pubkey.from_string(
     "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
 )
@@ -96,6 +103,7 @@ _QUOTE_MINT_OFFSET: Final[int] = 83
 _GLOBAL_INITIAL_REAL_TOKEN_RESERVES_OFFSET: Final[int] = 89
 
 _BAD_DISCRIMINATOR_MSG: Final[str] = "Invalid discriminator for bonding curve"
+_BAD_AUTH_TYPE_MSG: Final[str] = "GEYSER_AUTH_TYPE must be 'x-token' or 'basic'"
 
 # Quote assets. `quote_mint` is all zeros on SOL-paired coins, and the quote-side
 # reserves are in that mint's raw units — 1e9 for SOL, 1e6 for USDC.
@@ -138,35 +146,66 @@ def zero_prefix_gate(bound_raw: int) -> tuple[int, bytes] | None:
     return None
 
 
-def build_filters(bound_raw: int) -> list[dict[str, Any]]:
-    """Assemble the server-side `programSubscribe` filters.
+def build_subscribe_request(bound_raw: int) -> geyser_pb2.SubscribeRequest:
+    """Build the Geyser account subscription for near-graduation curves.
 
     Args:
         bound_raw: Highest qualifying `real_token_reserves`, in raw units
 
     Returns:
-        Filter dicts in the shape the RPC expects
+        The subscription request
     """
+    request = geyser_pb2.SubscribeRequest()
+    accounts = request.accounts["graduating_curves"]
+    accounts.owner.append(str(PUMP_PROGRAM_ID))
 
-    def memcmp(offset: int, raw: bytes) -> dict[str, Any]:
-        return {
-            "memcmp": {
-                "offset": offset,
-                "bytes": base64.b64encode(raw).decode(),
-                "encoding": "base64",
-            }
-        }
+    accounts.filters.add().datasize = CURVE_ACCOUNT_LEN
 
-    filters: list[dict[str, Any]] = [
-        {"dataSize": CURVE_ACCOUNT_LEN},
-        memcmp(0, BONDING_CURVE_DISCRIMINATOR),
-        memcmp(_COMPLETE_OFFSET, b"\x00"),  # Not graduated yet
-    ]
+    discriminator = accounts.filters.add().memcmp
+    discriminator.offset = 0
+    discriminator.bytes = BONDING_CURVE_DISCRIMINATOR
+
+    not_complete = accounts.filters.add().memcmp
+    not_complete.offset = _COMPLETE_OFFSET
+    not_complete.bytes = b"\x00"  # Not graduated yet
 
     gate = zero_prefix_gate(bound_raw)
     if gate:
-        filters.append(memcmp(*gate))
-    return filters
+        reserves = accounts.filters.add().memcmp
+        reserves.offset, reserves.bytes = gate
+
+    request.commitment = geyser_pb2.CommitmentLevel.PROCESSED
+    return request
+
+
+def create_geyser_connection() -> tuple[Any, grpc.aio.Channel]:
+    """Open an authenticated gRPC channel to the Geyser endpoint.
+
+    Returns:
+        The Geyser stub and the channel backing it
+
+    Raises:
+        ValueError: If GEYSER_AUTH_TYPE is not a supported scheme
+    """
+    if GEYSER_AUTH_TYPE == "x-token":
+        auth = grpc.metadata_call_credentials(
+            lambda _, callback: callback((("x-token", GEYSER_API_TOKEN),), None)
+        )
+    elif GEYSER_AUTH_TYPE == "basic":
+        auth = grpc.metadata_call_credentials(
+            lambda _, callback: callback(
+                (("authorization", f"Basic {GEYSER_API_TOKEN}"),), None
+            )
+        )
+    else:
+        raise ValueError(_BAD_AUTH_TYPE_MSG)
+
+    creds = grpc.composite_channel_credentials(grpc.ssl_channel_credentials(), auth)
+    endpoint = (
+        GEYSER_ENDPOINT.replace("https://", "").replace("http://", "").rstrip("/")
+    )
+    channel = grpc.aio.secure_channel(endpoint, creds)
+    return geyser_pb2_grpc.GeyserStub(channel), channel
 
 
 def parse_curve(data: bytes) -> dict[str, Any]:
@@ -229,9 +268,9 @@ async def resolve_mint(client: AsyncClient, curve: Pubkey) -> Pubkey | None:
 
     The curve account carries no mint field and `["bonding-curve", mint]` is not
     reversible, so this goes through the associated bonding curve — an ordinary ATA
-    owned by the curve. That ATA belongs to Token-2022 for `create_v2` coins, which
-    is every coin now being launched, so Token-2022 is tried first. The answer is
-    checked by re-deriving the curve PDA from the mint.
+    owned by the curve. That ATA belongs to Token-2022 for `create_v2` coins, which is
+    every coin now being launched, so Token-2022 is tried first. The answer is checked
+    by re-deriving the curve PDA from the mint.
 
     Args:
         client: Connected RPC client
@@ -262,6 +301,19 @@ async def resolve_mint(client: AsyncClient, curve: Pubkey) -> Pubkey | None:
     return None
 
 
+def progress_to_bound(baseline: float, min_progress: float) -> int:
+    """Convert a progress threshold into a raw `real_token_reserves` ceiling.
+
+    Args:
+        baseline: Launch-time real token reserves, in whole tokens
+        min_progress: Graduation progress threshold, as a percentage
+
+    Returns:
+        The highest raw reserves value that still qualifies
+    """
+    return int(baseline * (1 - min_progress / 100) * 10**TOKEN_DECIMALS)
+
+
 def print_banner(baseline: float, min_progress: float) -> None:
     """Describe the baseline and the filter that will be installed.
 
@@ -283,19 +335,6 @@ def print_banner(baseline: float, min_progress: float) -> None:
     else:
         print("Server-side gate: none (threshold too low to constrain)")
     print("Waiting for trades on qualifying curves...\n")
-
-
-def progress_to_bound(baseline: float, min_progress: float) -> int:
-    """Convert a progress threshold into a raw `real_token_reserves` ceiling.
-
-    Args:
-        baseline: Launch-time real token reserves, in whole tokens
-        min_progress: Graduation progress threshold, as a percentage
-
-    Returns:
-        The highest raw reserves value that still qualifies
-    """
-    return int(baseline * (1 - min_progress / 100) * 10**TOKEN_DECIMALS)
 
 
 class GraduationReporter:
@@ -327,7 +366,7 @@ class GraduationReporter:
         Args:
             curve: The bonding curve address
             data: Raw bonding curve account data
-            suffix: Extra provenance to append to the line, if the transport has any
+            suffix: Extra provenance to append to the line
         """
         try:
             state = parse_curve(data)
@@ -360,84 +399,67 @@ class GraduationReporter:
         )
 
 
-async def stream_once(
-    reporter: GraduationReporter, filters: list[dict[str, Any]]
-) -> None:
-    """Subscribe and consume notifications until the connection drops.
+async def stream_once(reporter: GraduationReporter, bound_raw: int) -> None:
+    """Subscribe over Geyser and consume account updates until the stream ends.
 
     Args:
         reporter: Sink for decoded curve updates
-        filters: Server-side filters for the subscription
-
-    Raises:
-        ConnectionRefusedError: If the endpoint rejects the subscription outright
+        bound_raw: Highest qualifying `real_token_reserves`, in raw units
     """
-    async with websockets.connect(WSS_ENDPOINT, max_size=None) as ws:
-        await ws.send(
-            json.dumps(
-                {
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "method": "programSubscribe",
-                    "params": [
-                        str(PUMP_PROGRAM_ID),
-                        {
-                            "encoding": "base64",
-                            "commitment": "processed",
-                            "filters": filters,
-                        },
-                    ],
-                }
+    stub, channel = create_geyser_connection()
+    try:
+        request = build_subscribe_request(bound_raw)
+        async for update in stub.Subscribe(iter([request])):
+            if not update.HasField("account"):
+                continue
+
+            account = update.account.account
+            signature = (
+                str(Signature(bytes(account.txn_signature)))
+                if account.txn_signature
+                else "<none>"
             )
-        )
-
-        ack = json.loads(await ws.recv())
-        if "error" in ack:
-            raise ConnectionRefusedError(str(ack["error"]))
-
-        while True:
-            # ConnectionClosed deliberately propagates to the reconnect handler in
-            # watch(). Swallowing it here would make every further recv() raise
-            # instantly, forever. A JSONDecodeError is per-message rather than
-            # per-connection, so that one is safe to skip.
-            try:
-                message = json.loads(await ws.recv())
-            except json.JSONDecodeError:
-                continue
-
-            if message.get("method") != "programNotification":
-                continue
-
-            value = message["params"]["result"]["value"]
             await reporter.handle(
-                Pubkey.from_string(value["pubkey"]),
-                base64.b64decode(value["account"]["data"][0]),
+                Pubkey.from_bytes(bytes(account.pubkey)),
+                bytes(account.data),
+                suffix=f"  slot={update.account.slot}  sig={signature}",
             )
+    finally:
+        await channel.close()
 
 
 async def watch(min_progress: float) -> None:
-    """Stream curve updates and report coins at or above `min_progress`.
+    """Stream curve updates over Geyser and report coins at or above `min_progress`.
 
     Args:
         min_progress: Graduation progress threshold, as a percentage
     """
-    if not WSS_ENDPOINT or not RPC_ENDPOINT:
-        print("❌ Set SOLANA_NODE_RPC_ENDPOINT and SOLANA_NODE_WSS_ENDPOINT in .env")
+    if not GEYSER_ENDPOINT or not GEYSER_API_TOKEN:
+        print("❌ Set GEYSER_ENDPOINT and GEYSER_API_TOKEN in .env")
+        return
+    if not RPC_ENDPOINT:
+        print("❌ Set SOLANA_NODE_RPC_ENDPOINT in .env (needed for Global and mints)")
         return
 
     async with AsyncClient(RPC_ENDPOINT) as client:
         baseline = await fetch_initial_real_token_reserves(client)
         print_banner(baseline, min_progress)
 
-        filters = build_filters(progress_to_bound(baseline, min_progress))
+        bound_raw = progress_to_bound(baseline, min_progress)
         reporter = GraduationReporter(client, baseline, min_progress)
 
         while True:
             try:
-                await stream_once(reporter, filters)
-            except ConnectionRefusedError as e:
-                print(f"❌ Subscription rejected: {e}")
+                await stream_once(reporter, bound_raw)
+            except ValueError as e:
+                print(f"❌ {e}")
                 return
+            except grpc.aio.AioRpcError as e:
+                print(
+                    f"⚠️ gRPC error ({e.code()}): {e.details()}; "
+                    f"reconnecting in {RECONNECT_DELAY}s"
+                )
+                await asyncio.sleep(RECONNECT_DELAY)
             except Exception as e:  # noqa: BLE001 - keep watching across hiccups
                 print(f"⚠️ {type(e).__name__}: {e}; reconnecting in {RECONNECT_DELAY}s")
                 await asyncio.sleep(RECONNECT_DELAY)
@@ -450,7 +472,7 @@ def main() -> None:
     sys.stdout.reconfigure(line_buffering=True)
 
     parser = argparse.ArgumentParser(
-        description="Report pump.fun coins approaching graduation, over WebSocket RPC"
+        description="Report pump.fun coins approaching graduation, over Geyser gRPC"
     )
     parser.add_argument(
         "--min-progress",


### PR DESCRIPTION
Closes #178.

## The problem

`get_graduating_tokens.py` asked for every bonding curve on the pump.fun program in one `getProgramAccounts` call. That program now owns over 10M accounts and no provider will serve it — Helius, Alchemy and dRPC reject on program size before filters apply, QuickNode and Chainstack time out.

**`getProgramAccountsV2` is not the fix the error message implies.** It is a provider extension (Helius, Solana Tracker), not core Agave — Agave 3.1's only `getProgramAccounts` change is that malformed filters now error instead of silently falling back to an unfiltered scan. And its `limit` is a *scan* budget rather than a result count: probing it, page 1 returned zero accounts alongside a non-null `paginationKey`, so one filtered answer over the pump program costs ~1000 strictly sequential round-trips.

## The approach

Filtered `programSubscribe`. `dataSize` and `memcmp` are applied server-side, and a curve can only approach graduation by being traded — every write pushes the full 151-byte account, so progress is computed per update with no accumulated state and no cold start beyond the next trade.

Measured over identical 45s windows:

| | filtered `programSubscribe` | Geyser account subscribe |
|---|---|---|
| Accepted on | configured endpoint **and** public `api.mainnet-beta.solana.com` | Chainstack Geyser |
| Updates | 6.5/s (7.2/s on public) | 9.6/s |
| Distinct near-graduation curves | 27 / 26 | 25 |
| Extras | — | slot, `txn_signature` |

Two independent scripts, following the `manual_buy.py` / `manual_buy_geyser.py` precedent:

- **`get_graduating_tokens.py`** — the portable path, runs on any endpoint including the public one.
- **`get_graduating_tokens_geyser.py`** — new; same report, plus the slot and signature behind each update. Geyser is a paid add-on but common among traders.

## What `--min-progress` can and cannot push to the server

The server-side pre-filter matches exact bytes, so it cannot express "anything above 90%" — only three fixed cutoffs (past ~64.5%, ~99.86%, ~99.9995% graduated). Each script picks the closest cutoff that is still wide enough and makes the exact comparison locally. Below 64.5% no cutoff applies, so every curve arrives and is filtered client-side.

That is a bandwidth tradeoff, not a correctness one: the percentage you ask for is honoured either way. Both scripts say which case you are in on startup.

## Two bugs fixed on the way

Neither is in the issue, and both would have survived a discovery-only rewrite:

- **The mint lookup was querying SPL Token.** The curve account has no mint field and `["bonding-curve", mint]` is not reversible, so the mint comes from the associated bonding curve ATA — which is Token-2022 for every `create_v2` coin. The old code hardcoded `TOKEN_PROGRAM_ID` and returns an empty list for all of them, silently, so the script would have found candidates and then printed no mints. Verified four for four on live curves, each confirmed by re-deriving the curve PDA from the recovered mint.
- **The threshold was a hardcoded 100 trillion.** Now measured against `Global.initial_real_token_reserves` read from chain, matching `poll_bonding_curve_progress.py` — a mayhem coin can launch with different virtual params and would otherwise show the wrong percentage.

Also: stdout is line-buffered, so redirecting to a file or piping to `grep` doesn't swallow output (block buffering loses everything if the process is killed).

## Verification

- Both scripts run live against mainnet, no funds moved.
- `ruff check` and `ruff format --check` clean on both files (the file being replaced had 1 pre-existing error).
- **The pre-filter was tested in both directions**, not just derived: a filtered and an unfiltered subscription run side by side over the same 60s window, on each transport. The filtered stream matched the below-cutoff set exactly — no false positives, no false negatives — with 143 of 168 curves above the cutoff on WebSocket and 128 of 154 on Geyser. This also caught a real bug: an earlier revision offered a fourth cutoff so high that no coin could fail it, leaving the subscription unfiltered while the banner reported a filter as active. Only cutoffs that actually narrow are offered now.
- Cutoff selection checked across thresholds from 0% to 99.99999% — never excludes a qualifying curve.
- One reported Geyser signature confirmed on chain: `err: None`, at the exact slot reported, curve present in the transaction.
- `dataSize: 151` confirmed not to drop live curves — over a 45s window all 205 updates across 24 curves were on the 151-byte layout; no legacy 49-byte curve is written to any more.

## Docs

- `CLAUDE.md` — replaced the "knowingly broken, needs the V2 pagination rewrite" note with the gPAv2 scan-budget finding, the filtered-subscription pattern, and the Token-2022 mint-resolution trap.
- `README.md` — both scripts listed in the examples table, and the throughput section now records that `getProgramAccounts` over the whole pump.fun program is no longer served by any provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added real-time monitoring for bonding curves nearing graduation, with a configurable minimum progress threshold.
  * Introduced two streaming modes: WebSocket-based watching and Geyser gRPC subscription support.
  * Improved output reliability with duplicate-update suppression and repeated reconnects, plus on-demand mint resolution with Token-2022 and legacy fallbacks.

* **Documentation**
  * Expanded guidance on practical curve discovery using filtered subscriptions, including provider pagination expectations and Token-2022 mint derivation notes.
  * Updated the README learning examples to reflect the new WebSocket/Geyser approaches for graduation progress monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
