### PR TITLE
fix(utils): decode omitted trailing optional args in IDL instruction decoder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,11 +151,13 @@ user-supplied and post-2026-04-28 may differ from the canonical `BC.creator`
 **not** set the flag; the geyser parser prefers `meta.log_messages` over
 instruction decoding for exactly this reason. `trade.trust_create_event:
 false` is the escape hatch back to always-refresh. PumpPortal payloads carry
-none of these fields and always refresh. Related pitfall: the strict IDL
-instruction decoder rejects `create_v2` transactions that omit the trailing
-`is_cashback_enabled` OptionBool (a legal wire form), so the instruction path
-alone silently misses those coins — one more reason the log/event path is
-preferred everywhere.
+none of these fields and always refresh. Related pitfall (fixed in #184): the
+IDL instruction decoder used to reject `create_v2` transactions that omit the
+trailing `is_cashback_enabled` OptionBool (a legal wire form), silently
+dropping those coins from the instruction path. It now reports omitted
+trailing option-typed args as unset — `verify_create_v2_optional_args.py`
+machine-checks that, and that mandatory args still fail the decode. The
+log/event path stays preferred for the canonical-creator reason above.
 
 ### Verifying transaction-status handling
 
@@ -315,7 +317,9 @@ The IDLs under `idl/` are vendored verbatim from `github.com/pump-fun/pump-publi
   `create_v2` instructions carry `0001` and `00` after `creator`: one sends both
   trailing args, the other omits the last. A decoder that reads a fixed number of
   trailing bytes raises `IndexError` on roughly half of all coins. Decode
-  trailing args defensively and report a missing one as unset.
+  trailing args defensively and report a missing one as unset —
+  `utils/idl_parser.py` does this for trailing option-typed args since #184
+  (`uv run learning-examples/verify_create_v2_optional_args.py` checks it).
 - `create_v2` accounts 1-16 are in the IDL; accounts **17-19 are optional
   remaining accounts** (`quote_mint`, `associated_quote_bonding_curve`,
   `quote_token_program`). All three or none. This is the only way to read a new

--- a/learning-examples/verify_create_v2_optional_args.py
+++ b/learning-examples/verify_create_v2_optional_args.py
@@ -1,0 +1,188 @@
+"""Verify the IDL instruction decoder accepts omitted trailing optional args.
+
+create_v2's trailing `is_cashback_enabled` OptionBool can legally be absent
+from the wire (issue #184): the committed blocksubscribe fixture carries a
+145-byte create_v2 whose args end right after `is_mayhem_mode`. A decoder
+that insists on the byte silently drops roughly half of all coins for every
+consumer of `parse_token_creation_from_instruction`.
+
+Offline machine checks, no network and no funds moved:
+
+  1. The raw fixture create_v2 (trailing OptionBool absent) decodes, with
+     `is_cashback_enabled` reported as unset (None).
+  2. The same data with the byte present still decodes to the OptionBool
+     struct form ({"field_0": bool}) consumers already handle.
+  3. Mandatory args stay enforced: truncating `is_mayhem_mode` as well must
+     fail the decode, not fabricate a default.
+  4. Native `option` types decode (update_buyback_config's Option<u64>):
+     None tag, Some tag, and omitted-trailing forms.
+  5. The pump.fun event parser turns the raw fixture instruction into a
+     TokenInfo with is_cashback_coin=False and state_from_event=False.
+
+Usage:
+    uv run learning-examples/verify_create_v2_optional_args.py
+"""
+
+import base64
+import json
+import struct
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from solders.transaction import VersionedTransaction  # noqa: E402
+
+from interfaces.core import Platform  # noqa: E402
+from platforms.pumpfun.event_parser import PumpFunEventParser  # noqa: E402
+from utils.idl_manager import get_idl_manager  # noqa: E402
+from utils.idl_parser import IDLParser  # noqa: E402
+
+FIXTURE = (
+    PROJECT_ROOT
+    / "learning-examples"
+    / "blocksubscribe-transactions"
+    / "raw_create_tx_from_blocksubscribe.json"
+)
+IDL_PATH = PROJECT_ROOT / "idl" / "pump_fun_idl.json"
+
+CREATE_V2_DISCRIMINATOR = bytes.fromhex("d6904cec5f8b31b4")
+UPDATE_BUYBACK_CONFIG_DISCRIMINATOR = bytes([251, 224, 171, 146, 160, 26, 113, 233])
+
+
+def _parser() -> IDLParser:
+    return IDLParser(str(IDL_PATH))
+
+
+def _fixture_create_v2() -> tuple[bytes, list[int], list[bytes]]:
+    """Raw create_v2 data, account indices and keys from the committed fixture."""
+    fixture = json.loads(FIXTURE.read_text())
+    raw = base64.b64decode(fixture["transaction"][0])
+    message = VersionedTransaction.from_bytes(raw).message
+    account_keys = [bytes(k) for k in message.account_keys]
+    for ix in message.instructions:
+        data = bytes(ix.data)
+        if data.startswith(CREATE_V2_DISCRIMINATOR):
+            return data, list(ix.accounts), account_keys
+    raise ValueError("fixture has no create_v2 instruction")  # noqa: TRY003
+
+
+def check_omitted_trailing_option_decodes() -> bool:
+    """The 145-byte wire form (no is_cashback_enabled byte) must decode."""
+    data, accounts, keys = _fixture_create_v2()
+    decoded = _parser().decode_instruction(data, keys, accounts)
+    if decoded is None:
+        print(f"    decode_instruction returned None for {len(data)}-byte create_v2")
+        return False
+    args = decoded["args"]
+    ok = (
+        decoded["instruction_name"] == "create_v2"
+        and args.get("is_cashback_enabled") is None
+        and args.get("is_mayhem_mode") is False
+        and bool(args.get("name"))
+        and bool(args.get("creator"))
+    )
+    if not ok:
+        print(f"    unexpected args: {args}")
+    return ok
+
+
+def check_present_trailing_option_unchanged() -> bool:
+    """With the byte on the wire, the OptionBool struct form must survive."""
+    data, accounts, keys = _fixture_create_v2()
+    parser = _parser()
+    for byte, expected in ((b"\x00", False), (b"\x01", True)):
+        decoded = parser.decode_instruction(data + byte, keys, accounts)
+        if decoded is None:
+            print(f"    decode failed with trailing byte {byte.hex()}")
+            return False
+        value = decoded["args"].get("is_cashback_enabled")
+        if not (isinstance(value, dict) and value.get("field_0") is expected):
+            print(f"    trailing byte {byte.hex()} decoded to {value}")
+            return False
+    return True
+
+
+def check_mandatory_args_still_enforced() -> bool:
+    """Dropping is_mayhem_mode (a plain bool) must fail, not default."""
+    data, accounts, keys = _fixture_create_v2()
+    decoded = _parser().decode_instruction(data[:-1], keys, accounts)
+    if decoded is not None:
+        print(f"    truncated create_v2 decoded anyway: {decoded['args']}")
+        return False
+    return True
+
+
+def check_native_option_decodes() -> bool:
+    """update_buyback_config carries Option<u64>: None, Some and omitted forms."""
+    parser = _parser()
+    cases = (
+        (UPDATE_BUYBACK_CONFIG_DISCRIMINATOR + b"\x00", None),
+        (UPDATE_BUYBACK_CONFIG_DISCRIMINATOR + b"\x01" + struct.pack("<Q", 250), 250),
+        (UPDATE_BUYBACK_CONFIG_DISCRIMINATOR, None),
+    )
+    for data, expected in cases:
+        decoded = parser.decode_instruction(data, [], [])
+        if decoded is None:
+            print(f"    decode returned None for {len(data)}-byte data")
+            return False
+        value = decoded["args"].get("buyback_basis_points")
+        if value != expected:
+            print(f"    expected {expected}, got {value}")
+            return False
+    return True
+
+
+def check_event_parser_reads_raw_fixture() -> bool:
+    """parse_token_creation_from_instruction must not need the appended byte."""
+    data, accounts, keys = _fixture_create_v2()
+    parser = PumpFunEventParser(
+        idl_parser=get_idl_manager().get_parser(Platform.PUMP_FUN)
+    )
+    token_info = parser.parse_token_creation_from_instruction(data, accounts, keys)
+    if token_info is None:
+        print("    parse_token_creation_from_instruction returned None")
+        return False
+    ok = (
+        token_info.is_cashback_coin is False
+        and getattr(token_info, "state_from_event", False) is False
+    )
+    if not ok:
+        print(
+            f"    is_cashback_coin={token_info.is_cashback_coin} "
+            f"state_from_event={getattr(token_info, 'state_from_event', None)}"
+        )
+    return ok
+
+
+def main() -> int:
+    checks = [
+        (
+            "omitted trailing OptionBool decodes as unset",
+            check_omitted_trailing_option_decodes,
+        ),
+        (
+            "present trailing OptionBool keeps struct form",
+            check_present_trailing_option_unchanged,
+        ),
+        ("mandatory args still enforced", check_mandatory_args_still_enforced),
+        ("native Option<u64> decodes", check_native_option_decodes),
+        ("event parser reads the raw fixture", check_event_parser_reads_raw_fixture),
+    ]
+    failed = 0
+    for label, check in checks:
+        try:
+            ok = check()
+        except Exception as error:  # noqa: BLE001 - report and continue
+            print(f"FAIL {label}: {type(error).__name__}: {error}")
+            failed += 1
+            continue
+        print(f"{'PASS' if ok else 'FAIL'} {label}")
+        failed += 0 if ok else 1
+    print(f"\n{len(checks) - failed}/{len(checks)} checks passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/learning-examples/verify_extreme_fast_zero_rpc.py
+++ b/learning-examples/verify_extreme_fast_zero_rpc.py
@@ -212,15 +212,11 @@ def check_instruction_parser_stays_conservative() -> bool:
     account_keys = [bytes(k) for k in msg.account_keys]
     parser = _event_parser()
     for ix in msg.instructions:
-        data = bytes(ix.data)
         # The fixture's create_v2 omits the trailing is_cashback_enabled
-        # OptionBool (a legal wire form the strict IDL decoder rejects — see
-        # the "decode trailing args defensively" gotcha in CLAUDE.md), so
-        # append the byte to exercise the parser's flag behaviour.
-        if data.startswith(bytes.fromhex("d6904cec5f8b31b4")):
-            data += b"\x00"
+        # OptionBool — a legal wire form the decoder accepts since #184
+        # (verify_create_v2_optional_args.py covers the decode itself).
         token_info = parser.parse_token_creation_from_instruction(
-            data, list(ix.accounts), account_keys
+            bytes(ix.data), list(ix.accounts), account_keys
         )
         if token_info is not None:
             ok = getattr(token_info, "state_from_event", False) is False

--- a/src/utils/idl_parser.py
+++ b/src/utils/idl_parser.py
@@ -15,6 +15,7 @@ DISCRIMINATOR_SIZE = 8
 PUBLIC_KEY_SIZE = 32
 STRING_LENGTH_PREFIX_SIZE = 4
 ENUM_DISCRIMINATOR_SIZE = 1
+OPTION_PREFIX_SIZE = 1
 
 
 class IDLParser:
@@ -110,19 +111,9 @@ class IDLParser:
         instruction = self.instructions[discriminator]
         data_args = ix_data[DISCRIMINATOR_SIZE:]
 
-        # Decode instruction arguments
-        args = {}
-        decode_offset = 0
-        for arg in instruction.get("args", []):
-            try:
-                value, decode_offset = self._decode_type(
-                    data_args, decode_offset, arg["type"]
-                )
-                args[arg["name"]] = value
-            except Exception as e:
-                if self.verbose:
-                    print(f"❌ Decode error in argument '{arg['name']}': {e}")
-                return None
+        args = self._decode_instruction_args(instruction, data_args)
+        if args is None:
+            return None
 
         # Helper to safely retrieve account public keys
         def get_account_key(index: int) -> str | None:
@@ -143,6 +134,37 @@ class IDLParser:
             "args": args,
             "accounts": account_info,
         }
+
+    def _decode_instruction_args(
+        self, instruction: dict[str, Any], data_args: bytes
+    ) -> dict[str, Any] | None:
+        """Decode instruction arguments, or None if the data is malformed.
+
+        Trailing option-typed args can legally be absent from the wire
+        (create_v2's is_cashback_enabled, issue #184): when the buffer is
+        exhausted and every remaining arg is optional, they are reported
+        as unset instead of failing the whole decode.
+        """
+        args: dict[str, Any] = {}
+        decode_offset = 0
+        arg_defs = instruction.get("args", [])
+        for i, arg in enumerate(arg_defs):
+            if decode_offset >= len(data_args) and all(
+                self._is_optional_type(remaining["type"]) for remaining in arg_defs[i:]
+            ):
+                for remaining in arg_defs[i:]:
+                    args[remaining["name"]] = None
+                break
+            try:
+                value, decode_offset = self._decode_type(
+                    data_args, decode_offset, arg["type"]
+                )
+                args[arg["name"]] = value
+            except Exception as e:
+                if self.verbose:
+                    print(f"❌ Decode error in argument '{arg['name']}': {e}")
+                return None
+        return args
 
     # --------------------------------------------------------------------------
     # Public Methods (External API) - Events
@@ -361,8 +383,15 @@ class IDLParser:
         """Calculate minimum data sizes for each instruction."""
         for discriminator, instruction in self.instructions.items():
             try:
+                required_args = list(instruction.get("args", []))
+                # Trailing option-typed args may be omitted from the wire
+                # entirely, so they contribute nothing to the minimum size.
+                while required_args and self._is_optional_type(
+                    required_args[-1]["type"]
+                ):
+                    required_args.pop()
                 min_size = DISCRIMINATOR_SIZE
-                for arg in instruction.get("args", []):
+                for arg in required_args:
                     min_size += self._calculate_type_min_size(arg["type"])
                 self.instruction_min_sizes[discriminator] = min_size
                 if self.verbose and instruction["name"] == "initialize":
@@ -385,10 +414,27 @@ class IDLParser:
                 element_type, array_length = type_def["array"]
                 element_size = self._calculate_type_min_size(element_type)
                 return element_size * array_length
+            if "option" in type_def:
+                # The None form is just the tag byte.
+                return OPTION_PREFIX_SIZE
 
         raise ValueError(
             f"Invalid or unknown type definition for size calculation: {type_def}"
         )
+
+    def _is_optional_type(self, type_def: str | dict) -> bool:
+        """Whether a type may legally be absent when it trails instruction data.
+
+        Covers Anchor's native ``option`` wrapper and pump.fun's ``OptionBool``
+        defined type — both are observed omitted from the wire when trailing.
+        """
+        if not isinstance(type_def, dict):
+            return False
+        if "option" in type_def:
+            return True
+        if "defined" in type_def:
+            return self._get_defined_type_name(type_def) == "OptionBool"
+        return False
 
     def _get_primitive_size(self, type_name: str) -> int:
         """Get size in bytes for primitive types from the central map."""
@@ -449,8 +495,22 @@ class IDLParser:
                 return self._decode_defined_type(data, offset, type_name)
             if "array" in type_def:
                 return self._decode_array(data, offset, type_def["array"])
+            if "option" in type_def:
+                return self._decode_option(data, offset, type_def["option"])
 
         raise ValueError(f"Invalid or unknown type definition for decoding: {type_def}")
+
+    def _decode_option(
+        self, data: bytes, offset: int, inner_type: str | dict
+    ) -> tuple[Any, int]:
+        """Decode Anchor's native option type: a 1-byte tag, then the value if Some."""
+        tag = struct.unpack_from("<B", data, offset)[0]
+        offset += OPTION_PREFIX_SIZE
+        if tag == 0:
+            return None, offset
+        if tag != 1:
+            raise ValueError(f"Invalid option tag {tag}")  # noqa: TRY003
+        return self._decode_type(data, offset, inner_type)
 
     def _decode_array(
         self, data: bytes, offset: int, array_def: list


### PR DESCRIPTION
Fixes #184

## Problem

`utils/idl_parser.py`'s `decode_instruction` rejected `create_v2` instructions whose wire data legally omits the trailing `is_cashback_enabled` OptionBool — a documented wire form seen on roughly half of all coins. Every consumer of `parse_token_creation_from_instruction` silently dropped those coins; since #183 that path is the fallback when log messages are absent, and the fallback still dropped them.

**Repro (pre-fix):** the committed fixture `learning-examples/blocksubscribe-transactions/raw_create_tx_from_blocksubscribe.json` carries a 145-byte `create_v2` (args end after `is_mayhem_mode`). The min-size gate passed, but decoding the trailing `OptionBool` raised `unpack_from requires a buffer of at least 138 bytes … (actual buffer size is 137)` and `decode_instruction` returned `None`. Appending a single `0x00` made it decode — the workaround `verify_extreme_fast_zero_rpc.py` had to carry.

## Fix

Mirrors the issue's proposed direction, in `src/utils/idl_parser.py`:

- **Omitted trailing optionals decode as unset.** When the arg buffer is exhausted and every remaining arg is option-typed (native `option` or pump.fun's `OptionBool` defined type), they are reported as `None` instead of failing the decode. Mandatory args still fail — truncating `is_mayhem_mode` as well returns `None`, never a fabricated default.
- **Min-size table counts trailing optional args as 0 bytes.**
- **Native `option` support** (`1-byte tag + value`) in both sizing and decoding — previously unsupported entirely: `update_buyback_config`'s `Option<u64>` could not even be sized at load (`Invalid or unknown type definition`).
- Present-form decoding is unchanged: `OptionBool` still decodes to `{"field_0": bool}`, which `platforms/pumpfun/event_parser.py` already handles (it also already handles `None`, so no consumer changes needed).

## Verification

New offline verifier, `uv run learning-examples/verify_create_v2_optional_args.py` (written first, 2/5 before the fix, 5/5 after):

1. raw 145-byte fixture `create_v2` decodes with `is_cashback_enabled` unset
2. present trailing byte keeps the `{"field_0": bool}` struct form
3. mandatory args still enforced (truncated data fails)
4. native `Option<u64>` decodes (None / Some / omitted forms)
5. `parse_token_creation_from_instruction` reads the raw fixture (`is_cashback_coin=False`, `state_from_event=False`)

Also passing: `verify_extreme_fast_zero_rpc.py` 9/9 (append-`0x00` workaround removed), `verify_pumpportal_buy_path.py` 5/5, `verify_v2_account_layout.py`, `verify_tx_status_checks.py`. `ruff check` on touched files leaves `idl_parser.py` with strictly fewer baseline violations than main (the args-loop extraction cleared a pre-existing `C901` on `decode_instruction`).

Docs: updated the two CLAUDE.md notes that described the strict decoder as a live pitfall.

Out of scope: `learning-examples/letsbonk-buy-sell/idl_parser.py` is a deliberately self-contained copy used only to build raydium-launchpad buy/sell instructions — nothing decodes an option-typed arg through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instruction parsing when trailing optional values are omitted.
  * Missing optional values are now reported as unset instead of causing decoding failures.
  * Required values continue to be validated, preventing incomplete instructions from being accepted.
  * Preserved correct handling of explicitly provided optional values and event-based token creation data.

* **Tests**
  * Added offline verification coverage for omitted and provided optional values, required arguments, and event parsing.

* **Documentation**
  * Updated the project guide with the revised optional-argument and token-refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->