### PR TITLE
fix(ci): restore the undefined warningMessage in spam-detection workflow

### DIFF
--- a/.github/workflows/spam-detection.yml
+++ b/.github/workflows/spam-detection.yml
@@ -92,6 +92,11 @@ jobs:
               
               // Trigger on either multiple patterns or high spam score
               if (foundPatterns.length > 2 || spamScore >= 3) {
+                const warningMessage =
+                  `⚠️ Potential scam detected in comment by ${author}:\n` +
+                  `- Suspicious patterns found: ${foundPatterns.join(', ')}\n` +
+                  `${suspiciousLinks ? '- Contains external links\n' : ''}` +
+                  `\n@${context.repo.owner} Please review this comment.`;
                 try {
                   // Create a warning comment
                   await github.rest.issues.createComment({


### PR DESCRIPTION
Closes #186.

The `spam-detection.yml` github-script step referenced `warningMessage` in `createComment`, but its definition was removed in `9ac0c27` while the usage was kept. When a comment tripped the threshold, the step threw `ReferenceError: warningMessage is not defined`, which the surrounding `try/catch` swallowed — so the scam-warning comment was never posted (only the `potential-scam` label was applied).

This restores the message just before it's used, built from the variables already in scope (`author`, `foundPatterns`, `suspiciousLinks`, `context.repo.owner`).

Verified: extracted the embedded script and ran `node --check` — syntax is valid and `warningMessage` is now defined before use.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Suspicious-comment warnings now provide clearer details about detected patterns and identify the comment author.
  * Warnings now call out external links when present and prompt review by the appropriate owner.
  * Automated moderation also applies the `potential-scam` label to help flag comments for follow-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->